### PR TITLE
Initial commit for adding a workflow step for adding a root of trust

### DIFF
--- a/vlei-verifier-workflows/src/utils/workflow-step-runners.ts
+++ b/vlei-verifier-workflows/src/utils/workflow-step-runners.ts
@@ -37,5 +37,17 @@ export class RevokeCredentialStepRunner extends StepRunner{
     }
 }
 
-
-
+export class addRootOfTrustStepRunner extends StepRunner{
+    type: string = "add_root_of_trust";
+    public async run(vi: VleiIssuance, stepName: string, step: any, configJson: any): Promise<any> {
+        const result = await vi.addRootOfTrust(configJson);
+        
+        // Check if the response was successful
+        if (!result.ok) {
+            throw new Error(`Failed to add root of trust: ${result.statusText}`);
+        }
+        
+        const response = await result.json();
+        return response;
+    }
+}

--- a/vlei-verifier-workflows/src/vlei-issuance.ts
+++ b/vlei-verifier-workflows/src/vlei-issuance.ts
@@ -31,6 +31,8 @@ import {
   Aid,
   sleep,
   revokeCredential,
+  addRootOfTrustSinglesig,
+  addRootOfTrustMultisig,
 } from "./utils/test-util";
 import {
   addEndRoleMultisig,
@@ -99,6 +101,7 @@ export class VleiIssuance {
   constructor(configJson: any) {
     this.configJson = configJson;
   }
+  
 
   public async prepareClients() {
     this.users = await buildUserData(this.configJson);
@@ -1462,5 +1465,126 @@ export class VleiIssuance {
       await buildTestData(testData, testName, issueeAidKey, "revoked_");
     }
     return [revCred, null];
+  }
+
+  public hasGLEIFWithMultisig(data: any): boolean {
+    return data.users.some(
+      (user: any) =>
+        (user.type === "GLEIF" || user.type === "GLEIF_EXTERNAL") &&
+        user.identifiers.some((id: any) => data.identifiers[id]?.identifiers),
+    );
+  }
+
+  public async addRootOfTrust(configJson: any): Promise<Response> {
+    if (this.hasGLEIFWithMultisig(configJson)) {
+      return await this.addRootOfTrustMultisig(configJson);
+    } else {
+      return await this.addRootOfTrustSinglesig(configJson);
+    }
+  }
+
+  public async addRootOfTrustMultisig(configJson: any): Promise<Response> {
+    const rootOfTrustMultisigIdentifierName = configJson.users
+      .filter(
+        (usr: any) => usr.type == "GLEIF" || usr.type == "GLEIF_EXTERNAL",
+      )[0]
+      .identifiers.filter((identifier: string) =>
+        identifier.includes("multisig"),
+      )![0];
+
+    const rootOfTrustIdentifierName = configJson.users
+      .filter(
+        (usr: any) => usr.type == "GLEIF" || usr.type == "GLEIF_EXTERNAL",
+      )[0]
+      .identifiers.filter(
+        (identifier: string) => !identifier.includes("multisig"),
+      )![0];
+
+    const rootOfTrustIdentifierAgent =
+      configJson.agents[
+        configJson.identifiers[rootOfTrustIdentifierName].agent
+      ];
+    const rootOfTrustIdentifierSecret =
+      configJson.secrets[rootOfTrustIdentifierAgent.secret];
+    const clients = await getOrCreateClients(
+      1,
+      [rootOfTrustIdentifierSecret],
+      true,
+    );
+    const client = clients[clients.length - 1];
+    const rootOfTrustAid = await client
+      .identifiers()
+      .get(rootOfTrustMultisigIdentifierName);
+
+    const oobi = await client
+      .oobis()
+      .get(rootOfTrustMultisigIdentifierName, "agent");
+    let oobiUrl = oobi.oobis[0];
+    const url = new URL(oobiUrl);
+    if (url.hostname === "keria")
+      oobiUrl = oobiUrl.replace("keria", "localhost");
+    console.log(`Root of trust OOBI: ${oobiUrl}`);
+    const oobiResp = await fetch(oobiUrl);
+    const oobiRespBody = await oobiResp.text();
+    const heads = new Headers();
+    heads.set("Content-Type", "application/json");
+    let lbody = {
+      vlei: oobiRespBody,
+      aid: rootOfTrustAid.prefix,
+      oobi: oobiUrl,
+    };
+    let lreq = {
+      headers: heads,
+      method: "POST",
+      body: JSON.stringify(lbody),
+    };
+    const lurl = `${this.apiBaseUrl}/add_root_of_trust`;
+    const lresp = await fetch(lurl, lreq);
+    return lresp;
+  }
+
+  public async addRootOfTrustSinglesig(configJson: any): Promise<Response> {
+    const rootOfTrustIdentifierName = configJson.users.filter(
+      (usr: any) => usr.type == "GLEIF",
+    )[0].identifiers[0];
+    const rootOfTrustIdentifierAgent =
+      configJson.agents[
+        configJson.identifiers[rootOfTrustIdentifierName].agent
+      ];
+    const rootOfTrustIdentifierSecret =
+      configJson.secrets[rootOfTrustIdentifierAgent.secret];
+    const clients = await getOrCreateClients(
+      1,
+      [rootOfTrustIdentifierSecret],
+      true,
+    );
+    const client = clients[clients.length - 1];
+    const rootOfTrustAid = await client
+      .identifiers()
+      .get(rootOfTrustIdentifierName);
+
+    const oobi = await client.oobis().get(rootOfTrustIdentifierName);
+    let oobiUrl = oobi.oobis[0];
+    console.log(`Root of trust OOBI: ${oobiUrl}`);
+    const url = new URL(oobiUrl);
+    if (url.hostname === "keria")
+      oobiUrl = oobiUrl.replace("keria", "localhost");
+    const oobiResp = await fetch(oobiUrl);
+    const oobiRespBody = await oobiResp.text();
+    const heads = new Headers();
+    heads.set("Content-Type", "application/json");
+    let lbody = {
+      vlei: oobiRespBody,
+      aid: rootOfTrustAid.prefix,
+      oobi: oobiUrl,
+    };
+    let lreq = {
+      headers: heads,
+      method: "POST",
+      body: JSON.stringify(lbody),
+    };
+    const lurl = `${this.apiBaseUrl}/add_root_of_trust`;
+    const lresp = await fetch(lurl, lreq);
+    return lresp;
   }
 }

--- a/vlei-verifier-workflows/src/workflows/singlesig-single-user-light.yaml
+++ b/vlei-verifier-workflows/src/workflows/singlesig-single-user-light.yaml
@@ -30,14 +30,14 @@ workflow:
       description: "LE issues ECR vLEI credential"
       credential: "le_to_ecr_vlei_cred"
       credential_source: "le_cred"
-    gen_report_ecr1:
-      id: "gen_report_ecr1"
-      type: "generate_report"
-      aid: "ecr-aid-1"
-      description: "Generating reports for ecr-aid-1 user"
-    api_test_ecr1:
-      id: "api_test_ecr1"
-      type: "api_test"
-      test_case: "api_test"
-      aids: ["ecr-aid-1"]
-      description: "Running API test for ecr-aid-1 user"
+    # gen_report_ecr1:
+    #   id: "gen_report_ecr1"
+    #   type: "generate_report"
+    #   aid: "ecr-aid-1"
+    #   description: "Generating reports for ecr-aid-1 user"
+    # api_test_ecr1:
+    #   id: "api_test_ecr1"
+    #   type: "api_test"
+    #   test_case: "api_test"
+    #   aids: ["ecr-aid-1"]
+    #   description: "Running API test for ecr-aid-1 user"


### PR DESCRIPTION
1) Added a workflow step for the root of trust
2) Added necessary functionality for the root of trust in vlei-issuance.ts
3) Added root of trust as a function to export in test-utils

Problems:
1) addRootOftrust functionality uses the apiBaseAdapter class and its constructor to initialize apiBaseUrl. I need some help to make changes that will incorporate apiBaseUrl. 

More suggestions and changes are welcome