### PR TITLE
add official vLEI schemas to project as reference

### DIFF
--- a/ref/ecr-authorization-vlei-credential.json
+++ b/ref/ecr-authorization-vlei-credential.json
@@ -1,0 +1,201 @@
+{
+  "$id": "EH6ekLjSr8V32WyFbGe1zXjTzFs9PkTYmupJ9H65O14g",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ECR Authorization vLEI Credential",
+  "description": "A vLEI Authorization Credential issued by a Legal Entity to a QVI for the authorization of ECR credentials",
+  "type": "object",
+  "credentialType": "ECRAuthorizationvLEICredential",
+  "version": "1.0.0",
+  "properties": {
+    "v": {
+      "description": "Version",
+      "type": "string"
+    },
+    "d": {
+      "description": "Credential SAID",
+      "type": "string"
+    },
+    "u": {
+      "description": "One time use nonce",
+      "type": "string"
+    },
+    "i": {
+      "description": "LE Issuer AID",
+      "type": "string"
+    },
+    "ri": {
+      "description": "Credential status registry",
+      "type": "string"
+    },
+    "s": {
+      "description": "Schema SAID",
+      "type": "string"
+    },
+    "a": {
+      "oneOf": [
+        {
+          "description": "Attributes block SAID",
+          "type": "string"
+        },
+        {
+          "$id": "EBMwtCJt7LUfA9u0jmZ1cAoCavZFIBmZBmlufYeX4gdy",
+          "description": "Attributes block",
+          "type": "object",
+          "properties": {
+            "d": {
+              "description": "Attributes block SAID",
+              "type": "string"
+            },
+            "i": {
+              "description": "QVI Issuee AID",
+              "type": "string"
+            },
+            "dt": {
+              "description": "Issuance date time",
+              "type": "string",
+              "format": "date-time"
+            },
+            "AID": {
+              "description": "AID of the intended recipient of the ECR credential",
+              "type": "string"
+            },
+            "LEI": {
+              "description": "LEI of the requesting Legal Entity",
+              "type": "string",
+              "format": "ISO 17442"
+            },
+            "personLegalName": {
+              "description": "Requested recipient name as provided during identity assurance",
+              "type": "string"
+            },
+            "engagementContextRole": {
+              "description": "Requested role description i.e. 'Head of Standards'",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "i",
+            "dt",
+            "AID",
+            "LEI",
+            "personLegalName",
+            "engagementContextRole"
+          ]
+        }
+      ]
+    },
+    "e": {
+      "oneOf": [
+        {
+          "description": "Edges block SAID",
+          "type": "string"
+        },
+        {
+          "$id": "EB6E1GJvVen5NqkKb2TG5jqX66vYOL3md-xkXQqQBySX",
+          "description": "Edges block",
+          "type": "object",
+          "properties": {
+            "d": {
+              "description": "Edges block SAID",
+              "type": "string"
+            },
+            "le": {
+              "description": "Chain to legal entity vLEI credential",
+              "type": "object",
+              "properties": {
+                "n": {
+                  "description": "QVI Issuer credential SAID",
+                  "type": "string"
+                },
+                "s": {
+                  "description": "SAID of required schema of the credential pointed to by this node",
+                  "type": "string",
+                  "const": "ENPXp1vQzRF6JwIuS-mp2U8Uf1MoADoP_GqQ62VsDZWY"
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "n",
+                "s"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "d",
+            "le"
+          ]
+        }
+      ]
+    },
+    "r": {
+      "oneOf": [
+        {
+          "description": "Rules block SAID",
+          "type": "string"
+        },
+        {
+          "$id": "ELLuSgEW2h8n5fHKLvZc9uTtxzqXQqlWR7MiwEt7AcmM",
+          "description": "Rules block",
+          "type": "object",
+          "properties": {
+            "d": {
+              "description": "Rules block SAID",
+              "type": "string"
+            },
+            "usageDisclaimer": {
+              "description": "Usage Disclaimer",
+              "type": "object",
+              "properties": {
+                "l": {
+                  "description": "Associated legal language",
+                  "type": "string",
+                  "const": "Usage of a valid, unexpired, and non-revoked vLEI Credential, as defined in the associated Ecosystem Governance Framework, does not assert that the Legal Entity is trustworthy, honest, reputable in its business dealings, safe to do business with, or compliant with any laws or that an implied or expressly intended purpose will be fulfilled."
+                }
+              }
+            },
+            "issuanceDisclaimer": {
+              "description": "Issuance Disclaimer",
+              "type": "object",
+              "properties": {
+                "l": {
+                  "description": "Associated legal language",
+                  "type": "string",
+                  "const": "All information in a valid, unexpired, and non-revoked vLEI Credential, as defined in the associated Ecosystem Governance Framework, is accurate as of the date the validation process was complete. The vLEI Credential has been issued to the legal entity or person named in the vLEI Credential as the subject; and the qualified vLEI Issuer exercised reasonable care to perform the validation process set forth in the vLEI Ecosystem Governance Framework."
+                }
+              }
+            },
+            "privacyDisclaimer": {
+              "description": "Privacy Disclaimer",
+              "type": "object",
+              "properties": {
+                "l": {
+                  "description": "Associated legal language",
+                  "type": "string",
+                  "const": "Privacy Considerations are applicable to QVI ECR AUTH vLEI Credentials.  It is the sole responsibility of QVIs as Issuees of QVI ECR AUTH vLEI Credentials to present these Credentials in a privacy-preserving manner using the mechanisms provided in the Issuance and Presentation Exchange (IPEX) protocol specification and the Authentic Chained Data Container (ACDC) specification.  https://github.com/WebOfTrust/IETF-IPEX and https://github.com/trustoverip/tswg-acdc-specification."
+                }
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "d",
+            "usageDisclaimer",
+            "issuanceDisclaimer",
+            "privacyDisclaimer"
+          ]
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "i",
+    "ri",
+    "s",
+    "d",
+    "e",
+    "r"
+  ]
+}

--- a/ref/ecr-authorization-vlei-credential.json
+++ b/ref/ecr-authorization-vlei-credential.json
@@ -115,17 +115,11 @@
                 }
               },
               "additionalProperties": false,
-              "required": [
-                "n",
-                "s"
-              ]
+              "required": ["n", "s"]
             }
           },
           "additionalProperties": false,
-          "required": [
-            "d",
-            "le"
-          ]
+          "required": ["d", "le"]
         }
       ]
     },
@@ -190,12 +184,5 @@
     }
   },
   "additionalProperties": false,
-  "required": [
-    "i",
-    "ri",
-    "s",
-    "d",
-    "e",
-    "r"
-  ]
+  "required": ["i", "ri", "s", "d", "e", "r"]
 }

--- a/ref/legal-entity-engagement-context-role-vLEI-credential.json
+++ b/ref/legal-entity-engagement-context-role-vLEI-credential.json
@@ -1,0 +1,245 @@
+{
+  "$id": "EEy9PkikFcANV1l7EHukCeXqrzT1hNZjGlUk7wuMO5jw",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Legal Entity Engagement Context Role vLEI Credential",
+  "description": "A vLEI Role Credential issued to representatives of a Legal Entity in other than official roles but in functional or other context of engagement",
+  "type": "object",
+  "credentialType": "LegalEntityEngagementContextRolevLEICredential",
+  "version": "1.0.0",
+  "properties": {
+    "v": {
+      "description": "Version",
+      "type": "string"
+    },
+    "d": {
+      "description": "Credential SAID",
+      "type": "string"
+    },
+    "u": {
+      "description": "A salty nonce",
+      "type": "string"
+    },
+    "i": {
+      "description": "QVI or LE Issuer AID",
+      "type": "string"
+    },
+    "ri": {
+      "description": "Credential status registry",
+      "type": "string"
+    },
+    "s": {
+      "description": "Schema SAID",
+      "type": "string"
+    },
+    "a": {
+      "oneOf": [
+        {
+          "description": "Attributes block SAID",
+          "type": "string"
+        },
+        {
+          "$id": "EDv4wiOMHE125CXu-EuOd0YRXz-AgpLilJfjoODFqtHD",
+          "description": "Attributes block",
+          "type": "object",
+          "properties": {
+            "d": {
+              "description": "Attributes block SAID",
+              "type": "string"
+            },
+            "u": {
+              "description": "A salty nonce",
+              "type": "string"
+            },
+            "i": {
+              "description": "Person Issuee AID",
+              "type": "string"
+            },
+            "dt": {
+              "description": "Issuance date time",
+              "type": "string",
+              "format": "date-time"
+            },
+            "LEI": {
+              "description": "LEI of the Legal Entity",
+              "type": "string",
+              "format": "ISO 17442"
+            },
+            "personLegalName": {
+              "description": "Recipient name as provided during identity assurance",
+              "type": "string"
+            },
+            "engagementContextRole": {
+              "description": "Role description i.e. 'Head of Standards'",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "i",
+            "dt",
+            "LEI",
+            "personLegalName",
+            "engagementContextRole"
+          ]
+        }
+      ]
+    },
+    "e": {
+      "oneOf": [
+        {
+          "description": "Edges block SAID",
+          "type": "string"
+        },
+        {
+          "$id": "EEM9OvWMEmAfAY0BV2kXatSc8WM13QW1B5y33E8z4f33",
+          "description": "Edges block",
+          "type": "object",
+          "properties": {
+            "d": {
+              "description": "Edges block SAID",
+              "type": "string"
+            },
+            "auth": {
+              "description": "Chain to Auth vLEI credential from legal entity",
+              "type": "object",
+              "properties": {
+                "n": {
+                  "description": "SAID of the ACDC to which the edge connects",
+                  "type": "string"
+                },
+                "s": {
+                  "description": "SAID of required schema of the credential pointed to by this node",
+                  "type": "string",
+                  "const": "EH6ekLjSr8V32WyFbGe1zXjTzFs9PkTYmupJ9H65O14g"
+                },
+                "o": {
+                  "description": "Operator indicating this node is the issuer",
+                  "type": "string",
+                  "const": "I2I"
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "n",
+                "s",
+                "o"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "d",
+            "auth"
+          ]
+        },
+        {
+          "$id": "EHeZGaLBhCc_-sAcyAEgFFeCkxgnqCubPOBuEvoh9jHX",
+          "description": "Edges block for issuance from Legal Entity",
+          "type": "object",
+          "properties": {
+            "d": {
+              "description": "SAID of edges block",
+              "type": "string"
+            },
+            "le": {
+              "description": "Chain to legal entity vLEI credential",
+              "type": "object",
+              "properties": {
+                "n": {
+                  "description": "SAID of the ACDC to which the edge connects",
+                  "type": "string"
+                },
+                "s": {
+                  "description": "SAID of required schema of the credential pointed to by this node",
+                  "type": "string",
+                  "const": "ENPXp1vQzRF6JwIuS-mp2U8Uf1MoADoP_GqQ62VsDZWY"
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "n",
+                "s"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "d",
+            "le"
+          ]
+        }
+      ]
+    },
+    "r": {
+      "oneOf": [
+        {
+          "description": "Rules block SAID",
+          "type": "string"
+        },
+        {
+          "$id": "EEBm6OIpem19B8BzxWXOAuzKTtYeutGpXMLW9o3pAuRe",
+          "description": "Rules block",
+          "type": "object",
+          "properties": {
+            "d": {
+              "description": "Rules block SAID",
+              "type": "string"
+            },
+            "usageDisclaimer": {
+              "description": "Usage Disclaimer",
+              "type": "object",
+              "properties": {
+                "l": {
+                  "description": "Associated legal language",
+                  "type": "string",
+                  "const": "Usage of a valid, unexpired, and non-revoked vLEI Credential, as defined in the associated Ecosystem Governance Framework, does not assert that the Legal Entity is trustworthy, honest, reputable in its business dealings, safe to do business with, or compliant with any laws or that an implied or expressly intended purpose will be fulfilled."
+                }
+              }
+            },
+            "issuanceDisclaimer": {
+              "description": "Issuance Disclaimer",
+              "type": "object",
+              "properties": {
+                "l": {
+                  "description": "Associated legal language",
+                  "type": "string",
+                  "const": "All information in a valid, unexpired, and non-revoked vLEI Credential, as defined in the associated Ecosystem Governance Framework, is accurate as of the date the validation process was complete. The vLEI Credential has been issued to the legal entity or person named in the vLEI Credential as the subject; and the qualified vLEI Issuer exercised reasonable care to perform the validation process set forth in the vLEI Ecosystem Governance Framework."
+                }
+              }
+            },
+            "privacyDisclaimer": {
+              "description": "Privacy Disclaimer",
+              "type": "object",
+              "properties": {
+                "l": {
+                  "description": "Associated legal language",
+                  "type": "string",
+                  "const": "It is the sole responsibility of Holders as Issuees of an ECR vLEI Credential to present that Credential in a privacy-preserving manner using the mechanisms provided in the Issuance and Presentation Exchange (IPEX) protocol specification and the Authentic Chained Data Container (ACDC) specification. https://github.com/WebOfTrust/IETF-IPEX and https://github.com/trustoverip/tswg-acdc-specification."
+                }
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "d",
+            "usageDisclaimer",
+            "issuanceDisclaimer",
+            "privacyDisclaimer"
+          ]
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "v",
+    "u",
+    "i",
+    "ri",
+    "s",
+    "d",
+    "r",
+    "a",
+    "e"
+  ]
+}

--- a/ref/legal-entity-engagement-context-role-vLEI-credential.json
+++ b/ref/legal-entity-engagement-context-role-vLEI-credential.json
@@ -119,18 +119,11 @@
                 }
               },
               "additionalProperties": false,
-              "required": [
-                "n",
-                "s",
-                "o"
-              ]
+              "required": ["n", "s", "o"]
             }
           },
           "additionalProperties": false,
-          "required": [
-            "d",
-            "auth"
-          ]
+          "required": ["d", "auth"]
         },
         {
           "$id": "EHeZGaLBhCc_-sAcyAEgFFeCkxgnqCubPOBuEvoh9jHX",
@@ -156,17 +149,11 @@
                 }
               },
               "additionalProperties": false,
-              "required": [
-                "n",
-                "s"
-              ]
+              "required": ["n", "s"]
             }
           },
           "additionalProperties": false,
-          "required": [
-            "d",
-            "le"
-          ]
+          "required": ["d", "le"]
         }
       ]
     },
@@ -231,15 +218,5 @@
     }
   },
   "additionalProperties": false,
-  "required": [
-    "v",
-    "u",
-    "i",
-    "ri",
-    "s",
-    "d",
-    "r",
-    "a",
-    "e"
-  ]
+  "required": ["v", "u", "i", "ri", "s", "d", "r", "a", "e"]
 }

--- a/ref/legal-entity-official-organizational-role-vLEI-credential.json
+++ b/ref/legal-entity-official-organizational-role-vLEI-credential.json
@@ -1,0 +1,190 @@
+{
+  "$id": "EBNaNu-M9P5cgrnfl2Fvymy4E_jvxxyjb70PRtiANlJy",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Legal Entity Official Organizational Role vLEI Credential",
+  "description": "A vLEI Role Credential issued by a Qualified vLEI issuer to official representatives of a Legal Entity",
+  "type": "object",
+  "credentialType": "LegalEntityOfficialOrganizationalRolevLEICredential",
+  "version": "1.0.0",
+  "properties": {
+    "v": {
+      "description": "Version",
+      "type": "string"
+    },
+    "d": {
+      "description": "Credential SAID",
+      "type": "string"
+    },
+    "u": {
+      "description": "One time use nonce",
+      "type": "string"
+    },
+    "i": {
+      "description": "QVI Issuer AID",
+      "type": "string"
+    },
+    "ri": {
+      "description": "Credential status registry",
+      "type": "string"
+    },
+    "s": {
+      "description": "Schema SAID",
+      "type": "string"
+    },
+    "a": {
+      "oneOf": [
+        {
+          "description": "Attributes block SAID",
+          "type": "string"
+        },
+        {
+          "$id": "ELDXjQ-FnKApK1DJhzmtKDcnfoJ9qusQr1Qz5g9MFt0o",
+          "description": "Attributes block",
+          "type": "object",
+          "properties": {
+            "d": {
+              "description": "Attributes block SAID",
+              "type": "string"
+            },
+            "i": {
+              "description": "Person Issuee AID",
+              "type": "string"
+            },
+            "dt": {
+              "description": "Issuance date time",
+              "type": "string",
+              "format": "date-time"
+            },
+            "LEI": {
+              "description": "LEI of the Legal Entity",
+              "type": "string",
+              "format": "ISO 17442"
+            },
+            "personLegalName": {
+              "description": "Recipient name as provided during identity assurance",
+              "type": "string"
+            },
+            "officialRole": {
+              "description": "Official role title",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "i",
+            "dt",
+            "LEI",
+            "personLegalName",
+            "officialRole"
+          ]
+        }
+      ]
+    },
+    "e": {
+      "oneOf": [
+        {
+          "description": "Edges block SAID",
+          "type": "string"
+        },
+        {
+          "$id": "EMsSqaJsthSBA4OINZ1_fxfNVkgEPF-Sg5fq-vXM7Z6b",
+          "description": "Edges block",
+          "type": "object",
+          "properties": {
+            "d": {
+              "description": "Edges block SAID",
+              "type": "string"
+            },
+            "auth": {
+              "description": "Chain to Auth vLEI credential from legal entity",
+              "type": "object",
+              "properties": {
+                "n": {
+                  "description": "SAID of the ACDC to which the edge connects",
+                  "type": "string"
+                },
+                "s": {
+                  "description": "SAID of required schema of the credential pointed to by this node",
+                  "type": "string",
+                  "const": "EKA57bKBKxr_kN7iN5i7lMUxpMG-s19dRcmov1iDxz-E"
+                },
+                "o": {
+                  "description": "Operator indicating this node is the issuer",
+                  "type": "string",
+                  "const": "I2I"
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "n",
+                "s",
+                "o"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "d",
+            "auth"
+          ]
+        }
+      ]
+    },
+    "r": {
+      "oneOf": [
+        {
+          "description": "Rules block SAID",
+          "type": "string"
+        },
+        {
+          "$id": "ECllqarpkZrSIWCb97XlMpEZZH3q4kc--FQ9mbkFMb_5",
+          "description": "Rules block",
+          "type": "object",
+          "properties": {
+            "d": {
+              "description": "Rules block SAID",
+              "type": "string"
+            },
+            "usageDisclaimer": {
+              "description": "Usage Disclaimer",
+              "type": "object",
+              "properties": {
+                "l": {
+                  "description": "Associated legal language",
+                  "type": "string",
+                  "const": "Usage of a valid, unexpired, and non-revoked vLEI Credential, as defined in the associated Ecosystem Governance Framework, does not assert that the Legal Entity is trustworthy, honest, reputable in its business dealings, safe to do business with, or compliant with any laws or that an implied or expressly intended purpose will be fulfilled."
+                }
+              }
+            },
+            "issuanceDisclaimer": {
+              "description": "Issuance Disclaimer",
+              "type": "object",
+              "properties": {
+                "l": {
+                  "description": "Associated legal language",
+                  "type": "string",
+                  "const": "All information in a valid, unexpired, and non-revoked vLEI Credential, as defined in the associated Ecosystem Governance Framework, is accurate as of the date the validation process was complete. The vLEI Credential has been issued to the legal entity or person named in the vLEI Credential as the subject; and the qualified vLEI Issuer exercised reasonable care to perform the validation process set forth in the vLEI Ecosystem Governance Framework."
+                }
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "d",
+            "usageDisclaimer",
+            "issuanceDisclaimer"
+          ]
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "i",
+    "ri",
+    "s",
+    "d",
+    "e",
+    "r"
+  ]
+}

--- a/ref/legal-entity-official-organizational-role-vLEI-credential.json
+++ b/ref/legal-entity-official-organizational-role-vLEI-credential.json
@@ -70,13 +70,7 @@
             }
           },
           "additionalProperties": false,
-          "required": [
-            "i",
-            "dt",
-            "LEI",
-            "personLegalName",
-            "officialRole"
-          ]
+          "required": ["i", "dt", "LEI", "personLegalName", "officialRole"]
         }
       ]
     },
@@ -115,18 +109,11 @@
                 }
               },
               "additionalProperties": false,
-              "required": [
-                "n",
-                "s",
-                "o"
-              ]
+              "required": ["n", "s", "o"]
             }
           },
           "additionalProperties": false,
-          "required": [
-            "d",
-            "auth"
-          ]
+          "required": ["d", "auth"]
         }
       ]
     },
@@ -169,22 +156,11 @@
             }
           },
           "additionalProperties": false,
-          "required": [
-            "d",
-            "usageDisclaimer",
-            "issuanceDisclaimer"
-          ]
+          "required": ["d", "usageDisclaimer", "issuanceDisclaimer"]
         }
       ]
     }
   },
   "additionalProperties": false,
-  "required": [
-    "i",
-    "ri",
-    "s",
-    "d",
-    "e",
-    "r"
-  ]
+  "required": ["i", "ri", "s", "d", "e", "r"]
 }

--- a/ref/legal-entity-vLEI-credential.json
+++ b/ref/legal-entity-vLEI-credential.json
@@ -1,0 +1,174 @@
+{
+  "$id": "ENPXp1vQzRF6JwIuS-mp2U8Uf1MoADoP_GqQ62VsDZWY",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Legal Entity vLEI Credential",
+  "description": "A vLEI Credential issued by a Qualified vLEI issuer to a Legal Entity",
+  "type": "object",
+  "credentialType": "LegalEntityvLEICredential",
+  "version": "1.0.0",
+  "properties": {
+    "v": {
+      "description": "Version",
+      "type": "string"
+    },
+    "d": {
+      "description": "Credential SAID",
+      "type": "string"
+    },
+    "u": {
+      "description": "One time use nonce",
+      "type": "string"
+    },
+    "i": {
+      "description": "QVI Issuer AID",
+      "type": "string"
+    },
+    "ri": {
+      "description": "Credential status registry",
+      "type": "string"
+    },
+    "s": {
+      "description": "Schema SAID",
+      "type": "string"
+    },
+    "a": {
+      "oneOf": [
+        {
+          "description": "Attributes block SAID",
+          "type": "string"
+        },
+        {
+          "$id": "EJ6bFDLrv50bHmIDg-MSummpvYWsPa9CFygPUZyHoESj",
+          "description": "Attributes block",
+          "type": "object",
+          "properties": {
+            "d": {
+              "description": "Attributes block SAID",
+              "type": "string"
+            },
+            "i": {
+              "description": "LE Issuer AID",
+              "type": "string"
+            },
+            "dt": {
+              "description": "issuance date time",
+              "type": "string",
+              "format": "date-time"
+            },
+            "LEI": {
+              "description": "LE Issuer AID",
+              "type": "string",
+              "format": "ISO 17442"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "i",
+            "dt",
+            "LEI"
+          ]
+        }
+      ]
+    },
+    "e": {
+      "oneOf": [
+        {
+          "description": "Edges block SAID",
+          "type": "string"
+        },
+        {
+          "$id": "EDh9sp5cPk0-yo5sFMo6WJS1HMBYIOYCwJrnPvNaH1vI",
+          "description": "Edges block",
+          "type": "object",
+          "properties": {
+            "d": {
+              "description": "Edges block SAID",
+              "type": "string"
+            },
+            "qvi": {
+              "description": "QVI node",
+              "type": "object",
+              "properties": {
+                "n": {
+                  "description": "Issuer credential SAID",
+                  "type": "string"
+                },
+                "s": {
+                  "description": "SAID of required schema of the credential pointed to by this node",
+                  "type": "string",
+                  "const": "EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao"
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "n",
+                "s"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "d",
+            "qvi"
+          ]
+        }
+      ]
+    },
+    "r": {
+      "oneOf": [
+        {
+          "description": "Rules block SAID",
+          "type": "string"
+        },
+        {
+          "$id": "ECllqarpkZrSIWCb97XlMpEZZH3q4kc--FQ9mbkFMb_5",
+          "description": "Rules block",
+          "type": "object",
+          "properties": {
+            "d": {
+              "description": "Rules block SAID",
+              "type": "string"
+            },
+            "usageDisclaimer": {
+              "description": "Usage Disclaimer",
+              "type": "object",
+              "properties": {
+                "l": {
+                  "description": "Associated legal language",
+                  "type": "string",
+                  "const": "Usage of a valid, unexpired, and non-revoked vLEI Credential, as defined in the associated Ecosystem Governance Framework, does not assert that the Legal Entity is trustworthy, honest, reputable in its business dealings, safe to do business with, or compliant with any laws or that an implied or expressly intended purpose will be fulfilled."
+                }
+              }
+            },
+            "issuanceDisclaimer": {
+              "description": "Issuance Disclaimer",
+              "type": "object",
+              "properties": {
+                "l": {
+                  "description": "Associated legal language",
+                  "type": "string",
+                  "const": "All information in a valid, unexpired, and non-revoked vLEI Credential, as defined in the associated Ecosystem Governance Framework, is accurate as of the date the validation process was complete. The vLEI Credential has been issued to the legal entity or person named in the vLEI Credential as the subject; and the qualified vLEI Issuer exercised reasonable care to perform the validation process set forth in the vLEI Ecosystem Governance Framework."
+                }
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "d",
+            "usageDisclaimer",
+            "issuanceDisclaimer"
+          ]
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "i",
+    "ri",
+    "s",
+    "d",
+    "e",
+    "r"
+  ]
+}

--- a/ref/legal-entity-vLEI-credential.json
+++ b/ref/legal-entity-vLEI-credential.json
@@ -62,11 +62,7 @@
             }
           },
           "additionalProperties": false,
-          "required": [
-            "i",
-            "dt",
-            "LEI"
-          ]
+          "required": ["i", "dt", "LEI"]
         }
       ]
     },
@@ -100,17 +96,11 @@
                 }
               },
               "additionalProperties": false,
-              "required": [
-                "n",
-                "s"
-              ]
+              "required": ["n", "s"]
             }
           },
           "additionalProperties": false,
-          "required": [
-            "d",
-            "qvi"
-          ]
+          "required": ["d", "qvi"]
         }
       ]
     },
@@ -153,22 +143,11 @@
             }
           },
           "additionalProperties": false,
-          "required": [
-            "d",
-            "usageDisclaimer",
-            "issuanceDisclaimer"
-          ]
+          "required": ["d", "usageDisclaimer", "issuanceDisclaimer"]
         }
       ]
     }
   },
   "additionalProperties": false,
-  "required": [
-    "i",
-    "ri",
-    "s",
-    "d",
-    "e",
-    "r"
-  ]
+  "required": ["i", "ri", "s", "d", "e", "r"]
 }

--- a/ref/oor-authorization-vlei-credential.json
+++ b/ref/oor-authorization-vlei-credential.json
@@ -1,0 +1,189 @@
+{
+  "$id": "EKA57bKBKxr_kN7iN5i7lMUxpMG-s19dRcmov1iDxz-E",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "OOR Authorization vLEI Credential",
+  "description": "A vLEI Authorization Credential issued by a Legal Entity to a QVI for the authorization of OOR credentials",
+  "type": "object",
+  "credentialType": "OORAuthorizationvLEICredential",
+  "version": "1.0.0",
+  "properties": {
+    "v": {
+      "description": "Version",
+      "type": "string"
+    },
+    "d": {
+      "description": "Credential SAID",
+      "type": "string"
+    },
+    "u": {
+      "description": "One time use nonce",
+      "type": "string"
+    },
+    "i": {
+      "description": "LE Issuer AID",
+      "type": "string"
+    },
+    "ri": {
+      "description": "Credential status registry",
+      "type": "string"
+    },
+    "s": {
+      "description": "Schema SAID",
+      "type": "string"
+    },
+    "a": {
+      "oneOf": [
+        {
+          "description": "Attributes block SAID",
+          "type": "string"
+        },
+        {
+          "$id": "EPli-kppZ4gj8g4i3-FUx3ZG1H_UrMhXwzyP1E6uAot6",
+          "description": "Attributes block",
+          "type": "object",
+          "properties": {
+            "d": {
+              "description": "Attributes block SAID",
+              "type": "string"
+            },
+            "i": {
+              "description": "QVI Issuee AID",
+              "type": "string"
+            },
+            "dt": {
+              "description": "Issuance date time",
+              "format": "date-time",
+              "type": "string"
+            },
+            "AID": {
+              "description": "AID of the intended recipient of the ECR credential",
+              "type": "string"
+            },
+            "LEI": {
+              "description": "LEI of the requesting Legal Entity",
+              "type": "string",
+              "format": "ISO 17442"
+            },
+            "personLegalName": {
+              "description": "Requested recipient name as provided during identity assurance",
+              "type": "string"
+            },
+            "officialRole": {
+              "description": "Requested role description i.e. 'Head of Standards'",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "i",
+            "dt",
+            "AID",
+            "LEI",
+            "personLegalName",
+            "officialRole"
+          ]
+        }
+      ]
+    },
+    "e": {
+      "oneOf": [
+        {
+          "description": "Edges block SAID",
+          "type": "string"
+        },
+        {
+          "$id": "EB6E1GJvVen5NqkKb2TG5jqX66vYOL3md-xkXQqQBySX",
+          "description": "Edges block",
+          "type": "object",
+          "properties": {
+            "d": {
+              "description": "Edges block SAID",
+              "type": "string"
+            },
+            "le": {
+              "description": "Chain to legal entity vLEI credential",
+              "type": "object",
+              "properties": {
+                "n": {
+                  "description": "QVI Issuer credential SAID",
+                  "type": "string"
+                },
+                "s": {
+                  "description": "SAID of required schema of the credential pointed to by this node",
+                  "type": "string",
+                  "const": "ENPXp1vQzRF6JwIuS-mp2U8Uf1MoADoP_GqQ62VsDZWY"
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "n",
+                "s"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "d",
+            "le"
+          ]
+        }
+      ]
+    },
+    "r": {
+      "oneOf": [
+        {
+          "description": "Rules block SAID",
+          "type": "string"
+        },
+        {
+          "$id": "ECllqarpkZrSIWCb97XlMpEZZH3q4kc--FQ9mbkFMb_5",
+          "description": "Rules block",
+          "type": "object",
+          "properties": {
+            "d": {
+              "description": "Rules block SAID",
+              "type": "string"
+            },
+            "usageDisclaimer": {
+              "description": "Usage Disclaimer",
+              "type": "object",
+              "properties": {
+                "l": {
+                  "description": "Associated legal language",
+                  "type": "string",
+                  "const": "Usage of a valid, unexpired, and non-revoked vLEI Credential, as defined in the associated Ecosystem Governance Framework, does not assert that the Legal Entity is trustworthy, honest, reputable in its business dealings, safe to do business with, or compliant with any laws or that an implied or expressly intended purpose will be fulfilled."
+                }
+              }
+            },
+            "issuanceDisclaimer": {
+              "description": "Issuance Disclaimer",
+              "type": "object",
+              "properties": {
+                "l": {
+                  "description": "Associated legal language",
+                  "type": "string",
+                  "const": "All information in a valid, unexpired, and non-revoked vLEI Credential, as defined in the associated Ecosystem Governance Framework, is accurate as of the date the validation process was complete. The vLEI Credential has been issued to the legal entity or person named in the vLEI Credential as the subject; and the qualified vLEI Issuer exercised reasonable care to perform the validation process set forth in the vLEI Ecosystem Governance Framework."
+                }
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "d",
+            "usageDisclaimer",
+            "issuanceDisclaimer"
+          ]
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "i",
+    "ri",
+    "s",
+    "d",
+    "e",
+    "r"
+  ]
+}

--- a/ref/oor-authorization-vlei-credential.json
+++ b/ref/oor-authorization-vlei-credential.json
@@ -115,17 +115,11 @@
                 }
               },
               "additionalProperties": false,
-              "required": [
-                "n",
-                "s"
-              ]
+              "required": ["n", "s"]
             }
           },
           "additionalProperties": false,
-          "required": [
-            "d",
-            "le"
-          ]
+          "required": ["d", "le"]
         }
       ]
     },
@@ -168,22 +162,11 @@
             }
           },
           "additionalProperties": false,
-          "required": [
-            "d",
-            "usageDisclaimer",
-            "issuanceDisclaimer"
-          ]
+          "required": ["d", "usageDisclaimer", "issuanceDisclaimer"]
         }
       ]
     }
   },
   "additionalProperties": false,
-  "required": [
-    "i",
-    "ri",
-    "s",
-    "d",
-    "e",
-    "r"
-  ]
+  "required": ["i", "ri", "s", "d", "e", "r"]
 }

--- a/ref/qualified-vLEI-issuer-vLEI-credential.json
+++ b/ref/qualified-vLEI-issuer-vLEI-credential.json
@@ -1,0 +1,133 @@
+{
+  "$id": "EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Qualified vLEI Issuer Credential",
+  "description": "A vLEI Credential issued by GLEIF to Qualified vLEI Issuers which allows the Qualified vLEI Issuers to issue, verify and revoke Legal Entity vLEI Credentials and Legal Entity Official Organizational Role vLEI Credentials",
+  "type": "object",
+  "credentialType": "QualifiedvLEIIssuervLEICredential",
+  "version": "1.0.0",
+  "properties": {
+    "v": {
+      "description": "Version",
+      "type": "string"
+    },
+    "d": {
+      "description": "Credential SAID",
+      "type": "string"
+    },
+    "u": {
+      "description": "One time use nonce",
+      "type": "string"
+    },
+    "i": {
+      "description": "GLEIF Issuee AID",
+      "type": "string"
+    },
+    "ri": {
+      "description": "Credential status registry",
+      "type": "string"
+    },
+    "s": {
+      "description": "Schema SAID",
+      "type": "string"
+    },
+    "a": {
+      "oneOf": [
+        {
+          "description": "Attributes block SAID",
+          "type": "string"
+        },
+        {
+          "$id": "ELGgI0fkloqKWREXgqUfgS0bJybP1LChxCO3sqPSFHCj",
+          "description": "Attributes block",
+          "type": "object",
+          "properties": {
+            "d": {
+              "description": "Attributes block SAID",
+              "type": "string"
+            },
+            "i": {
+              "description": "QVI Issuee AID",
+              "type": "string"
+            },
+            "dt": {
+              "description": "Issuance date time",
+              "type": "string",
+              "format": "date-time"
+            },
+            "LEI": {
+              "description": "LEI of the requesting Legal Entity",
+              "type": "string",
+              "format": "ISO 17442"
+            },
+            "gracePeriod": {
+              "description": "Allocated grace period",
+              "type": "integer",
+              "default": 90
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "i",
+            "dt",
+            "LEI"
+          ]
+        }
+      ]
+    },
+    "r": {
+      "oneOf": [
+        {
+          "description": "Rules block SAID",
+          "type": "string"
+        },
+        {
+          "$id": "ECllqarpkZrSIWCb97XlMpEZZH3q4kc--FQ9mbkFMb_5",
+          "description": "Rules block",
+          "type": "object",
+          "properties": {
+            "d": {
+              "description": "Rules block SAID",
+              "type": "string"
+            },
+            "usageDisclaimer": {
+              "description": "Usage Disclaimer",
+              "type": "object",
+              "properties": {
+                "l": {
+                  "description": "Associated legal language",
+                  "type": "string",
+                  "const": "Usage of a valid, unexpired, and non-revoked vLEI Credential, as defined in the associated Ecosystem Governance Framework, does not assert that the Legal Entity is trustworthy, honest, reputable in its business dealings, safe to do business with, or compliant with any laws or that an implied or expressly intended purpose will be fulfilled."
+                }
+              }
+            },
+            "issuanceDisclaimer": {
+              "description": "Issuance Disclaimer",
+              "type": "object",
+              "properties": {
+                "l": {
+                  "description": "Associated legal language",
+                  "type": "string",
+                  "const": "All information in a valid, unexpired, and non-revoked vLEI Credential, as defined in the associated Ecosystem Governance Framework, is accurate as of the date the validation process was complete. The vLEI Credential has been issued to the legal entity or person named in the vLEI Credential as the subject; and the qualified vLEI Issuer exercised reasonable care to perform the validation process set forth in the vLEI Ecosystem Governance Framework."
+                }
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "d",
+            "usageDisclaimer",
+            "issuanceDisclaimer"
+          ]
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "i",
+    "ri",
+    "s",
+    "d"
+  ]
+}

--- a/ref/qualified-vLEI-issuer-vLEI-credential.json
+++ b/ref/qualified-vLEI-issuer-vLEI-credential.json
@@ -67,11 +67,7 @@
             }
           },
           "additionalProperties": false,
-          "required": [
-            "i",
-            "dt",
-            "LEI"
-          ]
+          "required": ["i", "dt", "LEI"]
         }
       ]
     },
@@ -114,20 +110,11 @@
             }
           },
           "additionalProperties": false,
-          "required": [
-            "d",
-            "usageDisclaimer",
-            "issuanceDisclaimer"
-          ]
+          "required": ["d", "usageDisclaimer", "issuanceDisclaimer"]
         }
       ]
     }
   },
   "additionalProperties": false,
-  "required": [
-    "i",
-    "ri",
-    "s",
-    "d"
-  ]
+  "required": ["i", "ri", "s", "d"]
 }


### PR DESCRIPTION
Official vLEI schema, as referenced in the governance documents, are now available for reference in a directory called `ref`.