### PR TITLE
Fix npm packaging problems

### DIFF
--- a/build/test/package/check-compatibility.sh
+++ b/build/test/package/check-compatibility.sh
@@ -1,14 +1,20 @@
 #!/bin/bash
 
+# Store the base directory of the script dynamically, so we can navigate to the root of the project whenever needed
+BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 runNodeTest() {
     printf "\n\e[34m***********\n"
     printf "* Node.js *\n"
     printf "***********\e[0m\n\n"
     
-    cd "build/test/package/node" || { echo "Directory not found"; exit 1; }
+    cd "$BASE_DIR/node" || { echo "Directory not found"; exit 1; }
     rm -rf node_modules
     npm run node-test || { echo "Node test failed"; exit 1; }
 }
+
+# Ensure we always start from the base directory
+cd "$BASE_DIR" || { echo "Failed to navigate to base directory"; exit 1; }
 
 echo "Checking compatibility..."
 runNodeTest

--- a/build/test/package/node/package.json
+++ b/build/test/package/node/package.json
@@ -3,8 +3,9 @@
   "version": "1.0.0",
   "main": "script.js",
   "scripts": {
-    "node-test": "npm run linker && node ./esm/script.js && node ./cjs/script.js",
-    "linker": "npx link \"$(npm prefix)/../../../../\""
+    "node-test": "npm run linker && node ./esm/script.js && node ./cjs/script.js && npm run unlinker",
+    "linker": "npx link \"$(npm prefix)/../../../../\"",
+    "unlinker": "npx link -u \"$(npm prefix)/../../../../\""
   },
   "author": "",
   "license": "",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gleif-it/vlei-verifier-workflows",
-  "version": "0.0.6-dev.3",
+  "version": "0.0.6-dev.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gleif-it/vlei-verifier-workflows",
-      "version": "0.0.6-dev.3",
+      "version": "0.0.6-dev.4",
       "license": "Apache-2.0",
       "dependencies": {
         "buffer": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,21 @@
       }
     }
   },
-  "types": "./dist/cjs/types/index.d.ts",
+  "module": "./dist/esm/index.js",
   "main": "./dist/cjs/index.js",
+  "types": "./dist/esm/types/index.d.ts",
+  "typesVersions": {
+    "<=4.9": {
+      "*": [
+        "dist/cjs/types/*"
+      ]
+    },
+    ">=5.0": {
+      "*": [
+        "dist/esm/types/*"
+      ]
+    }
+  },
   "files": [
     "dist/**/*"
   ],
@@ -58,7 +71,7 @@
     "compatibility-checker": "./build/test/package/check-compatibility.sh",
     "package-checker": "npm pack --dry-run",
     "prepublishOnly": "npm run test:full",
-    "publish:dev": "npm version prerelease --preid=dev && npm publish --access public --tag dev"
+    "publish:dev": "npm version prerelease --preid=dev && npm publish --access public --tag dev && npm dist-tag add $(node -p \"require('./package.json').name + '@' + require('./package.json').version\") latest"
   },
   "dependencies": {
     "buffer": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gleif-it/vlei-verifier-workflows",
-  "version": "0.0.6-dev.3",
+  "version": "0.0.6-dev.4",
   "description": "Workflows for vLEI users and vLEI credentials for the vLEI-verifier service",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
- I've found cases where `esm` projects are pulling in the code from `dist/cjs`. These changes are meant to obviate that. In the cases I'm aware of, it does seem to. I've checked `esm` ("type": "module") and `cjs` ("type": "commonjs") and both seem to behave correctly now.

- I've also, updated the `publish:dev` script a bit to ensure the latest dev version is always shown.